### PR TITLE
存在しないファイルでの誤発動を防ぐ

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -39,7 +39,7 @@
   "`auto-sudoedit' hook."
   (let ((curr-path (auto-sudoedit-current-path)))
     (unless (or
-             (f-writable? curr-path)
+             (f-traverse-upwards #'f-writable? curr-path)
              (tramp-tramp-file-p curr-path))
       (auto-sudoedit-sudoedit-and-kill))))
 

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -37,10 +37,11 @@
 
 (defun auto-sudoedit ()
   "`auto-sudoedit' hook."
-  (unless (or
-           (f-writable? (auto-sudoedit-current-path))
-           (tramp-tramp-file-p (auto-sudoedit-current-path)))
-    (auto-sudoedit-sudoedit-and-kill)))
+  (let ((curr-path (auto-sudoedit-current-path)))
+    (unless (or
+             (f-writable? curr-path)
+             (tramp-tramp-file-p curr-path))
+      (auto-sudoedit-sudoedit-and-kill))))
 
 ;;;###autoload
 (define-minor-mode


### PR DESCRIPTION
普段 `(auto-sudoedit-mode 1)` で使わせていただいています。

まだ存在しないディレクトリの中でファイルを開くことがあります。たとえば `~/foo` は存在しないとして、`C-x C-f ~/foo/bar.txt` を行って `M-x make-directory RET RET` で後から `~/foo` を作ります。

このようにすると、`~/foo` の書き込み権限を持っているのに（`sudo` は不要なのに）auto-sudoedit が発動します。原因は `f-writable?` と `tramp-tramp-file-p` の両方が `nil` を返し、書き込み権限を持っていないファイルとの区別がつきません。

対策として、パスを順に遡って `f-writable?` を実行することを提案したいと思います。こうすれば書き込みできる親ディレクトリを見つけて無駄な発動を防ぎ、また書き込みできる親がなければ通常どおり発動します。