### PR TITLE
Using advice-around instead of hook trigger for mode enable.

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -24,9 +24,9 @@
   (interactive (auto-sudoedit-current-path))
   (find-file (auto-sudoedit-tramp-path s)))
 
-(defun auto-sudoedit (_old_func &rest _args)
+(defun auto-sudoedit (orig-func &rest args)
   "`auto-sudoedit' around-advice."
-  (let ((curr-path (car _args)))
+  (let ((curr-path (car args)))
     (if (not
          (or
           ;; Don't activate for tramp files
@@ -38,9 +38,9 @@
         (let ((first-existing-path (f-traverse-upwards #'f-exists? curr-path)))
           (if (not (and first-existing-path (f-writable? first-existing-path)))
               (let ((tramp-path (auto-sudoedit-tramp-path curr-path)))
-                (apply _old_func tramp-path (cdr _args)))
-            (apply _old_func _args)))
-      (apply _old_func _args))))
+                (apply orig-func tramp-path (cdr args)))
+            (apply orig-func args)))
+      (apply orig-func args))))
 
 ;;;###autoload
 (define-minor-mode

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -19,36 +19,28 @@
   "Argument S is tramp sudo path."
   (concat "/sudo::" s))
 
-(defun auto-sudoedit-current-path ()
-  "Current path file or dir."
-  (or (buffer-file-name) list-buffers-directory))
-
 (defun auto-sudoedit-sudoedit (s)
   "Open sudoedit.  Argument S is path."
   (interactive (auto-sudoedit-current-path))
   (find-file (auto-sudoedit-tramp-path s)))
 
-(defun auto-sudoedit-sudoedit-and-kill ()
-  "Open sudoedit and kill."
-  (interactive)
-  (let ((old-buffer-name (auto-sudoedit-current-path)))
-    (kill-this-buffer)
-    (auto-sudoedit-sudoedit old-buffer-name)))
-
-(defun auto-sudoedit ()
-  "`auto-sudoedit' hook."
-  (let ((curr-path (auto-sudoedit-current-path)))
-    (unless
-        (or
-         ;; Don't activate for tramp files
-         (tramp-tramp-file-p curr-path)
-         ;; Don't activate on sudo do not exist
-         (not (executable-find "sudo")))
-      ;; Current path may not exist; back up to the first existing parent
-      ;; and see if it's writable
-      (let ((first-existing-path (f-traverse-upwards #'f-exists? curr-path)))
-        (unless (and first-existing-path (f-writable? first-existing-path))
-          (auto-sudoedit-sudoedit-and-kill))))))
+(defun auto-sudoedit (_old_func &rest _args)
+  "`auto-sudoedit' around-advice."
+  (let ((curr-path (car _args)))
+    (if (not
+         (or
+          ;; Don't activate for tramp files
+          (tramp-tramp-file-p curr-path)
+          ;; Don't activate on sudo do not exist
+          (not (executable-find "sudo"))))
+        ;; Current path may not exist; back up to the first existing parent
+        ;; and see if it's writable
+        (let ((first-existing-path (f-traverse-upwards #'f-exists? curr-path)))
+          (if (not (and first-existing-path (f-writable? first-existing-path)))
+              (let ((tramp-path (auto-sudoedit-tramp-path curr-path)))
+                (apply _old_func tramp-path (cdr _args)))
+            (apply _old_func _args)))
+      (apply _old_func _args))))
 
 ;;;###autoload
 (define-minor-mode
@@ -58,12 +50,10 @@
   :lighter " ASE"
   (if auto-sudoedit-mode
       (progn
-        (add-hook 'find-file-hook  'auto-sudoedit)
-        (add-hook 'dired-mode-hook 'auto-sudoedit)
-        )
-    (remove-hook 'find-file-hook  'auto-sudoedit)
-    (remove-hook 'dired-mode-hook 'auto-sudoedit)
-    ))
+        (advice-add 'find-file :around 'auto-sudoedit)
+        (advice-add 'dired :around 'auto-sudoedit))
+    (advice-remove 'find-file 'auto-sudoedit)
+    (advice-remove 'dired 'auto-sudoedit)))
 
 (provide 'auto-sudoedit)
 


### PR DESCRIPTION
The original funcition 'auto-sudoedit-sudoedit-and-kill' using buffer redirect method to replace the origin dired displayed buffer with the tramped one, and indeed that this procedure working for the hook both for 'dired-mode-hook' or 'find-file-hook' caused by the original 'auto -sudoedit-mode' trigger. But for thus, the 'kill-this-buffer' way will corrupted the origin buffer argument for the next hook rounder which will destroyed the whole dired or find-file initializing procedure.

For avoiding this problem, this commit using the around-advices re-wrappering the 'dired' and 'find-file' which just transfer the tramp-transfered path for the rest process powered by the original package builtin function 'auto-sudoedit-tramp-path'.