### PR TITLE
Extract activation logic

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -2,7 +2,7 @@
 
 ;; Author: ncaq <ncaq@ncaq.net>
 ;; Version: 0.0.0
-;; Package-Requires: ((emacs "24")(f "0.19.0"))
+;; Package-Requires: ((emacs "24.4")(f "0.19.0"))
 ;; URL: https://github.com/ncaq/auto-sudoedit
 
 ;;; Commentary:

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -24,15 +24,19 @@
   (interactive (auto-sudoedit-current-path))
   (find-file (auto-sudoedit-tramp-path s)))
 
+(defun auto-sudoedit-should-activate (curr-path)
+  "Return non-nil if auto-sudoedit should activate for CURR-PATH."
+  (not
+   (or
+    ;; Don't activate for tramp files
+    (tramp-tramp-file-p curr-path)
+    ;; Don't activate on sudo do not exist
+    (not (executable-find "sudo")))))
+
 (defun auto-sudoedit (orig-func &rest args)
   "`auto-sudoedit' around-advice."
   (let ((curr-path (car args)))
-    (if (not
-         (or
-          ;; Don't activate for tramp files
-          (tramp-tramp-file-p curr-path)
-          ;; Don't activate on sudo do not exist
-          (not (executable-find "sudo"))))
+    (if (auto-sudoedit-should-activate curr-path)
         ;; Current path may not exist; back up to the first existing parent
         ;; and see if it's writable
         (let ((first-existing-path (f-traverse-upwards #'f-exists? curr-path)))


### PR DESCRIPTION
There are some files I frequently need to open that are not writable, but I basically never want to sudo-open them. These would be e.g. system Python files or elisp files bundled with Emacs itself. I define functions to identify such files and use advice like so to disable auto-sudoedit for them:

```lisp
  (defun auto-sudoedit--skip-if-internal (old-function &rest args)
    (let ((path (auto-sudoedit-current-path)))
      (unless (or (emacs-internal-file-p path)
                  (python-system-file-p path)
                  (go-system-file-p path))
        (apply old-function args))))
  (advice-add #'auto-sudoedit :around #'auto-sudoedit--skip-if-internal)
```

With #6 auto-sudoedit has itself become an advice function, and so advising it feels a bit dangerous. Instead I propose refactoring the "should-activate" logic to a separate function that I could then advise like so:

```lisp
  (defun auto-sudoedit--skip-if-internal (old-function &rest args)
    (let ((path (car args)))
      (unless (or (emacs-internal-file-p path)
                  (python-system-file-p path)
                  (go-system-file-p path))
        (apply old-function args))))
  (advice-add #'auto-sudoedit-should-activate :around #'auto-sudoedit--skip-if-internal)
```