### PR TITLE
Fix interactive, no-prefix usage of `auto-sudoedit-sudoedit`

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -21,7 +21,7 @@
 
 (defun auto-sudoedit-sudoedit (s)
   "Open sudoedit.  Argument S is path."
-  (interactive (auto-sudoedit-current-path))
+  (interactive (list (auto-sudoedit-current-path)))
   (find-file (auto-sudoedit-tramp-path s)))
 
 (defun auto-sudoedit (orig-func &rest args)


### PR DESCRIPTION
When not given a string, `interactive` takes a *list* of args; per doc:

> If the argument is not a string, it is evaluated to get a list of
>  arguments to pass to the command.