### PR TITLE
build: nix-templatesのbasicテンプレートを適用して開発環境を整備

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((lsp-format-buffer-on-save . t))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,60 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# URLなどは分割困難で長過ぎることがあるためしばしば例外が許可されます。
+# あくまで指針と各種フォーマッターへの指示です。
+max_line_length = 120
+
+# デフォルトのインデントをスペースで2幅にして例外の方を設定することにします。
+# これもcheckerがインデントではないものを誤認することがあるので、
+# あくまで指針と各種フォーマッターへの指示です。
+indent_style = space
+indent_size = 2
+
+# 標準インデントが4の言語。
+[*.{cs,csx,java,kt,kts,php,py,pyi,rs}]
+indent_size = 4
+
+# 標準インデントがタブの言語。
+[{*.go,*.make,*.mk,Makefile}]
+indent_style = tab
+indent_size = unset
+
+# Emacs Lispは独特なインデントルールを持つためeditorconfig側では指定しません。
+[*.el]
+indent_size = unset
+indent_style = unset
+
+[*.md]
+# Markdownには最後にスペース2つ入れて強制改行するシンタックスがあるので末尾のスペースを許可。
+# 注意: なるべく強制改行は使わず、意味で段落して、改行位置はクライアントのデバイスに任せるべきです。
+trim_trailing_whitespace = false
+# MarkdownはCommonMark準拠パーサーでは箇条書きリストのネストは2スペースでも動作し、
+# 番号付きリストはマーカー幅に依存するため固定値での指定は不適切です。
+# よって値を指定しません。
+indent_size = unset
+
+[*.{json,md,nix,yml,yaml}]
+# 設定やドキュメントのファイルはURLなど改行困難なものが多いため行幅制限を無効化します。
+max_line_length = unset
+
+[.env{,.*}]
+# 接続文字列やAPIキーなど長い設定値を含むため行幅制限を無効化します。
+max_line_length = unset
+
+[*.bat]
+charset = latin1
+end_of_line = crlf
+
+[*.ps1]
+charset = utf-8-bom
+end_of_line = crlf
+
+[*.reg]
+charset = utf-8-bom
+end_of_line = crlf

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 開発時に使う共有の環境変数を読み込みます。
+# `dotenv_if_exists`はファイルが存在しなければ何もしません。
+# deveはtypoではなく、deve, prod, stag, testと四文字に揃えた略称です。
+dotenv_if_exists .env.deve
+
+# Nix Flakesの開発環境をロードします。
+use flake . --accept-flake-config
+
+# GitHub MCPのために各自のGitHubのTokenを取得します。
+# `GITHUB_TOKEN`にトークンを展開することは一般的に行われていることであり、
+# 危険性はほぼありません。
+# 悪意を持って環境変数にアクセスできる状況ならばどうせ基本的に`gh auth token`も起動できるはずです。
+if gh auth status &>/dev/null; then
+  GITHUB_TOKEN=$(gh auth token)
+  export GITHUB_TOKEN
+else
+  # GitHub MCPにアクセスできなくても致命的な状況ではないので、
+  # エラーログだけ出して続行します。
+  log_error "GitHub CLI is not authenticated. Please run 'gh auth login' first."
+fi
+
+# ローカル固有の環境変数を最後に読み込んで優先させます。
+dotenv_if_exists .env.local

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,56 @@
+name: Setup Nix
+description: Install Nix and configure caches
+
+inputs:
+  extra-nix-config:
+    description: Additional nix.conf settings to append
+    required: false
+    default: ""
+  cachix-name:
+    description: Cachix cache name
+    required: false
+    default: ncaq
+  cachix-auth-token:
+    description: Cachix authentication token
+    required: false
+    default: ""
+  niks3-endpoint:
+    description: niks3 server endpoint URL
+    required: false
+    default: "https://niks3-public.ncaq.net"
+
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+      with:
+        # セルフホストランナーでうっかり外部からの悪意あるPRを実行許可してしまい、
+        # flake.nixの設定を受け入れると好きなキャッシュを入れられたりしてセキュリティリスクがあるため、
+        # GitHubホステッドランナーでのみflake.nixの設定を自動で受け入れるようにしています。
+        # GitHubホステッドランナーでは`runner.environment`は`github-hosted`になります。
+        # 仮にならなくてもキャッシュリストが読み込まれないだけなのでアクションの実行でわかるため、
+        # セキュリティのリスクはありません。
+        extra_nix_config: |
+          ${{ runner.environment == 'github-hosted' && 'accept-flake-config = true' || '' }}
+          ${{ inputs.extra-nix-config }}
+
+    - name: Setup Cachix cache
+      if: inputs.cachix-name != '' && inputs.cachix-auth-token != ''
+      uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      with:
+        name: "${{ inputs.cachix-name }}"
+        authToken: "${{ inputs.cachix-auth-token }}"
+        # フォークからのPRのみキャッシュへのプッシュをスキップ
+        skipPush: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+    # niks3-actionではskip-pushがpost-build hookに反映されないバグがあり、
+    # push失敗時にビルド全体が巻き込まれて失敗する。
+    # secretが渡らないフォークPRではaction自体をスキップする。
+    # See: https://github.com/aleadag/niks3-action/issues/3
+    - name: Setup niks3 cache
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: aleadag/niks3-action@8935c349a257dfc311834684bfbd4ab6c4ce6c86 # v0.5.0
+      with:
+        endpoint: "${{ inputs.niks3-endpoint }}"
+        use-oidc: true
+        push-flake-inputs: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# 出力設定
+
+## 言語
+
+AIは人間に話すときは日本語を使ってください。
+
+しかし既存のコードのコメントなどが日本語ではない場合は、
+コメント等は既存の言語に合わせてください。
+
+## 記号
+
+ASCIIに対応する全角形(Fullwidth Forms)は使用禁止。
+
+具体的には以下のような文字:
+
+- 全角括弧 `（）` → 半角 `()`
+- 全角コロン `：` → 半角 `:`
+- 全角カンマ `，` → 半角 `,`
+- 全角数字 `０-９` → 半角 `0-9`
+
+# 重要コマンド
+
+## フォーマット
+
+nix fmtでフォーマットとリントを実行できます。
+
+```console
+nix fmt
+```
+
+[nix-tasuke](https://github.com/ncaq/konoka/tree/master/plugins/nix-tasuke)プラグインにより、
+Claudeの応答完了時にStopフックで`nix fmt`が自動実行されます。
+ファイルの差分が出ることがあります。
+
+## 統合チェック
+
+nix-fast-buildコマンドで統合チェックを実行できます。
+
+```console
+nix-fast-build --option eval-cache false --no-link --skip-cached --no-nom
+```
+
+# リポジトリ構成
+
+Codex向けの`AGENTS.md`とClaude Code向けの`CLAUDE.md`は以下のように`.github/copilot-instructions.md`のシンボリックリンクになっています。
+
+```console
+AGENTS.md -> .github/copilot-instructions.md
+CLAUDE.md -> .github/copilot-instructions.md
+```
+
+これにより各種LLM向けのドキュメントを一元管理しています。

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,148 @@
+日本語で記述してください。
+
+Conventional Commitsを使います。
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages.
+It provides an easy set of rules for creating an explicit commit history;
+which makes it easier to write automated tools on top of.
+
+The commit message should be structured as follows:
+
+---
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+---
+
+The commit contains the following structural elements, to communicate intent to the
+consumers of your library:
+
+1. **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+1. **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+1. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `!` after the type/scope, introduces a breaking API change
+   (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning).
+   A BREAKING CHANGE can be part of commits of any _type_.
+1. _types_ other than `fix:` and `feat:` are allowed, for example
+   [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+   (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines))
+   recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+1. _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to
+   [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE).
+A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `!` to draw attention to breaking change
+
+```
+feat!: send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `!` to draw attention to breaking change
+
+```
+feat(api)!: send an email to the customer when a product is shipped
+```
+
+### Commit message with both `!` and BREAKING CHANGE footer
+
+```
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed
+   by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+1. The type `feat` MUST be used when a commit adds a new feature to your application or library.
+1. The type `fix` MUST be used when a commit represents a bug fix for your application.
+1. A scope MAY be provided after a type. A scope MUST consist of a noun describing a
+   section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+1. A description MUST immediately follow the colon and space after the type/scope prefix.
+   The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+1. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+1. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+1. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of
+   a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the
+   [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+1. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate
+   the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+1. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer
+   token/separator pair is observed.
+1. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the
+   footer.
+1. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g.,
+   _BREAKING CHANGE: environment variables now take precedence over config files_.
+1. If included in the type/scope prefix, breaking changes MUST be indicated by a
+   `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY be omitted from the footer section,
+   and the commit description SHALL be used to describe the breaking change.
+1. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs._
+1. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+1. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+# type
+
+Must be one of the following:
+
+- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- **ci**: Changes to our CI configuration files and scripts
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - "Type: Release"
+
+  categories:
+    - title: Security Fixes
+      labels: ["Type: Security"]
+    - title: Breaking Changes
+      labels: ["Type: Breaking Change"]
+    - title: Features
+      labels: ["Type: Feature"]
+    - title: Bug Fixes
+      labels: ["Type: Bug"]
+    - title: Documentation
+      labels: ["Type: Documentation"]
+    - title: Refactoring
+      labels: ["Type: Refactoring"]
+    - title: Testing
+      labels: ["Type: Testing"]
+    - title: CI
+      labels: ["Type: CI"]
+    - title: Dependency Updates
+      labels: ["Type: Dependencies", "dependencies"]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,48 @@
+name: check
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-fast-build:
+    name: nix-fast-build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      id-token: write # niks3 OIDC認証
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
+  elisp-check:
+    name: elisp-check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      id-token: write # niks3 OIDC認証
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: leotaku/elisp-check@cbcda75256a9195b5e6d7e6fa39390b32e08a4f3 # v1.4.1
+        with:
+          file: "auto-sudoedit*.el"
+          warnings_as_errors: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,9 @@ jobs:
       - uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: purcell/setup-emacs@bdc64dc730ae1fcba200bfd52cb1b4cf6159cbe5 # v8.0
+        with:
+          version: snapshot # 最新のバージョンで実行してEmacs正式リリースより先にエラーを検出。
       - uses: leotaku/elisp-check@cbcda75256a9195b5e6d7e6fa39390b32e08a4f3 # v1.4.1
         with:
           file: "auto-sudoedit*.el"

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -1,0 +1,21 @@
+name: Kyosei
+
+on:
+  pull_request:
+    # Only opened and synchronize to avoid duplicate reviews
+    # on the same revision from ready_for_review or reopened events.
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  workflow:
+    # Reusable workflows are constrained by the caller's permissions,
+    # so they must be explicitly declared here.
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
+    uses: ncaq/kyosei-action/.github/workflows/review.yml@b382b91e7bc94738d7de5f6fa41b4299e83bf126 # v1.2.0
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: release
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- branchesで制限済み、信頼できない入力は使用していない
+  workflow_run:
+    workflows: [check]
+    types: [completed]
+    branches: [master, main]
+
+permissions: {}
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # タグ作成のため
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: "${{ github.event.workflow_run.head_sha }}"
+          persist-credentials: false
+          fetch-depth: 0 # タグの存在確認と作成に全履歴が必要
+      - name: Extract version from Emacs Lisp header
+        id: version
+        run: |
+          set -euo pipefail
+          # Emacs Lispパッケージヘッダの`;; Version:`からバージョンを抽出する。
+          VERSION=$(sed -n 's/^;; Version: *//p' auto-sudoedit.el | tr -d '[:space:]')
+          if [ -z "$VERSION" ]; then
+            echo "No version found in auto-sudoedit.el"
+            exit 1
+          elif ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid semver format: $VERSION"
+            exit 1
+          else
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check if tag exists
+        id: check-tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git show-ref --verify --quiet "refs/tags/v$VERSION"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create tag
+        if: steps.check-tag.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+      - name: Create GitHub Release
+        if: steps.check-tag.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "v$VERSION" --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
+# Nix
+
+# Ignore build outputs from performing a nix-build or `nix build` command
+result
+result-*
+
+# Ignore automatically generated direnv output
+.direnv
+
+# Ignore local override env
+.env.local
+
+# Emacs Lisp
+
 *-autoloads.el
 *.elc

--- a/.marksman.toml
+++ b/.marksman.toml
@@ -1,0 +1,2 @@
+[core]
+title_from_heading = false

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Place it in melpa or directly downloaded by PATH.
 
 If downloaded directly
 
-~~~ el
+```el
 (require 'auto-sudoedit)
-~~~
+```
 
 auto-sudoedit works when minor mode is enabled.
 
-~~~ el
+```el
 (auto-sudoedit-mode 1)
-~~~
+```
 
 If you enable minor mode,
 When you open a file that requires root privileges,
@@ -38,9 +38,9 @@ It will be reopened automatically.
 
 If you find the following message depressing
 
-~~~~
+```
 Autosave file on local temporary directory, do you want to continue? (y or n) y
-~~~~
+```
 
 On a non-shared PC, you can allow some security risk and use.
 Set `tramp-allow-unsafe-temporary-files` to `t`.
@@ -64,15 +64,15 @@ melpaか直接ダウンロードでPATHが通った場所に置きます。
 
 直接ダウンロードした場合は、
 
-~~~el
+```el
 (require 'auto-sudoedit)
-~~~
+```
 
 auto-sudoeditはマイナーモードが有効の時に動きます。
 
-~~~el
+```el
 (auto-sudoedit-mode 1)
-~~~
+```
 
 マイナーモードを有効にしておけば、
 root権限が必要なファイルを開いたときに、
@@ -82,9 +82,9 @@ root権限が必要なファイルを開いたときに、
 
 もし以下のメッセージが鬱陶しいならば、
 
-~~~
+```
 Autosave file on local temporary directory, do you want to continue? (y or n) y
-~~~
+```
 
 共有してないPCでは多少のセキュリティリスクを許容して、
 `tramp-allow-unsafe-temporary-files`

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,9 @@
+[default.extend-words]
+# Part of "RGBa" (Pillow's pre-multiplied alpha RGB mode)
+Ba = "Ba"
+# HSA is something AMD uses for their GPUs
+HSA = "HSA"
+# 社名。分割で認識されなくなります。
+Hashi = "Hashi"
+# Immediately Invoked Function Expression (IIFE)の略語。camelCase分割で"IIF"をtypoと判定する。
+IIF = "IIF"

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -18,8 +18,7 @@
 (require 'tramp)
 (require 'tramp-sh)
 
-(defcustom auto-sudoedit-ask
-  nil
+(defcustom auto-sudoedit-ask nil
   "Ask for user confirmation when reopening?"
   :group 'auto-sudoedit
   :type 'boolean)
@@ -33,14 +32,16 @@ USER is nil, when we cannot open via sudo."
   (let* ((file-owner (auto-sudoedit-file-owner curr-path))
          (tramp-path
           (if (tramp-tramp-file-p curr-path)
-              (auto-sudoedit-path-from-tramp-ssh-like curr-path file-owner)
+              (auto-sudoedit-path-from-tramp-ssh-like
+               curr-path file-owner)
             (concat "/sudo::" curr-path))))
     (if (and
          ;; We must know the file owner's login name
          ;; If we can't, we don't know which user to sudo as
          file-owner
          ;; The file owner must be different from our current user so that the sudo makes sense
-         (not (string= file-owner (auto-sudoedit-current-user curr-path)))
+         (not
+          (string= file-owner (auto-sudoedit-current-user curr-path)))
          ;; 変換前のパスと同じでなく(2回めの変換はしない)
          (not (equal curr-path tramp-path)))
         (cons file-owner tramp-path)
@@ -71,7 +72,16 @@ NEW-USER is the user for sudo."
          (new-host host)
          (new-port port)
          (new-localname localname)
-         (new-hop (format "%s%s:%s%s%s|" (or hop "") method (if user (concat user "@") "") host (if port (concat port "#") ""))))
+         (new-hop
+          (format "%s%s:%s%s%s|"
+                  (or hop "") method
+                  (if user
+                      (concat user "@")
+                    "")
+                  host
+                  (if port
+                      (concat port "#")
+                    ""))))
     ;; 最終メソッドがsudoである場合それ以上の変換は無意味なので行わない。
     (if (equal method "sudo")
         curr-path
@@ -100,14 +110,20 @@ Reopen the buffer via tramp with sudo method."
          (remote-info (auto-sudoedit-path curr-path))
          (user (car remote-info))
          (tramp-path (cdr remote-info)))
-    (when (and
-           curr-path
-           user
-           tramp-path
-           (not (and (tramp-tramp-file-p curr-path) (tramp-sh-handle-file-writable-p curr-path)))
-           (or
-            (not auto-sudoedit-ask)
-            (y-or-n-p (format "This buffer belongs to user %s.  Reopen this buffer as user %s? " user user))))
+    (when
+        (and
+         curr-path
+         user
+         tramp-path
+         (not
+          (and (tramp-tramp-file-p curr-path)
+               (tramp-sh-handle-file-writable-p curr-path)))
+         (or
+          (not auto-sudoedit-ask)
+          (y-or-n-p
+           (format
+            "This buffer belongs to user %s.  Reopen this buffer as user %s? "
+            user user))))
       ;; We have to tell emacs that this buffer now visits another file (actually the same one, just via tramp sudo)
       ;; We have to do things differently for normal files and for dired
       (when buffer-file-name
@@ -133,12 +149,12 @@ Reopen the buffer via tramp with sudo method."
       (revert-buffer t t))))
 
 ;;;###autoload
-(define-minor-mode
-  auto-sudoedit-mode
+(define-minor-mode auto-sudoedit-mode
   "When sudo is required, it automatically reopens in tramp."
   :global t
   :init-value 0
-  :lighter " ASE"
+  :lighter
+  " ASE"
   (if auto-sudoedit-mode
       (progn
         (add-hook 'find-file-hook #'auto-sudoedit)

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -26,7 +26,7 @@
 (defun auto-sudoedit-path (curr-path)
   "To convert path to tramp using sudo path.
 Argument CURR-PATH is current path.
-The result is a cons cell in the format '(USER . TRAMP-PATH).
+The result is a cons cell in the format \\='(USER . TRAMP-PATH).
 USER is nil, when we cannot open via sudo."
   ;; trampのpathに変換します
   (let* ((file-owner (auto-sudoedit-file-owner curr-path))
@@ -151,6 +151,7 @@ Reopen the buffer via tramp with sudo method."
 ;;;###autoload
 (define-minor-mode auto-sudoedit-mode
   "When sudo is required, it automatically reopens in tramp."
+  :group 'auto-sudoedit
   :global t
   :init-value 0
   :lighter

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "emacs-elisp-autofmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775532385,
+        "narHash": "sha256-w9vq+BJrV+A2RFY3VrYHgvfFkEH62NGpvllYqsDI/ro=",
+        "ref": "refs/heads/main",
+        "rev": "b1cdd8661930a35b1633ccc28b27b793145cd108",
+        "revCount": 365,
+        "type": "git",
+        "url": "https://codeberg.org/ideasman42/emacs-elisp-autofmt.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/ideasman42/emacs-elisp-autofmt.git"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "emacs-elisp-autofmt": "emacs-elisp-autofmt",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,122 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    emacs-elisp-autofmt = {
+      url = "git+https://codeberg.org/ideasman42/emacs-elisp-autofmt.git";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      treefmt-nix,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        treefmt-nix.flakeModule
+      ];
+
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      perSystem =
+        {
+          pkgs,
+          ...
+        }:
+        {
+          treefmt.config = {
+            projectRootFile = "flake.nix";
+            programs = {
+              actionlint.enable = true;
+              deadnix.enable = true;
+              nixfmt.enable = true;
+              prettier.enable = true;
+              shellcheck.enable = true;
+              shfmt.enable = true;
+              statix.enable = true;
+              typos.enable = true;
+              zizmor.enable = true;
+            };
+            settings.formatter = {
+              editorconfig-checker = {
+                command = pkgs.editorconfig-checker;
+                includes = [ "*" ];
+              };
+              elisp-autofmt = {
+                command = pkgs.writeShellApplication {
+                  name = "elisp-autofmt";
+                  runtimeInputs = with pkgs; [
+                    emacs
+                    python3
+                  ];
+                  text = ''
+                    python3 ${inputs.emacs-elisp-autofmt}/elisp-autofmt-cmd.py "$@"
+                  '';
+                };
+                includes = [ "*.el" ];
+              };
+              zizmor.options = [ "--pedantic" ];
+            };
+          };
+
+          packages = {
+            # flake.lockの管理バージョンをre-exportすることで安定した利用を促進。
+            inherit (pkgs)
+              nix-fast-build
+              ;
+          };
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              # treefmtで指定したプログラムの単体版。
+              actionlint
+              deadnix
+              editorconfig-checker
+              emacsPackages.elisp-autofmt
+              nixfmt
+              prettier
+              shellcheck
+              shfmt
+              statix
+              typos
+              zizmor
+
+              # nixの関連ツール。
+              nil
+              nix-fast-build
+
+              # GitHub関連ツール。
+              gh
+
+              # Emacs関連ツール。
+              emacs
+            ];
+          };
+        };
+    };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org/"
+      "https://niks3-public.ncaq.net/"
+      "https://ncaq.cachix.org/"
+      "https://nix-community.cachix.org/"
+    ];
+    extra-trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "niks3-public.ncaq.net-1:e/B9GomqDchMBmx3IW/TMQDF8sjUCQzEofKhpehXl04="
+      "ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ncaq/renovate-config"]
+}

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,3 @@
+disabled = [
+  "eta_reduction", # nixfmtによるフォーマットと衝突するため無効化。
+]


### PR DESCRIPTION
長期間メンテナンスされていなかったリポジトリに、
nix-templatesのbasicテンプレートをベースとした開発環境を導入します。

主な変更内容:
- Nix Flakes開発環境(`flake.nix`, `flake.lock`)の追加
- treefmtによるフォーマット・リント統合(elisp-autofmt含む)
- GitHub Actions CI(`nix-fast-build`, `elisp-check`, Kyosei PRレビュー)の追加
- `auto-sudoedit.el`の`;; Version:`ヘッダから自動リリースするworkflowの追加
- direnv(`.envrc`)、editorconfig、MCP設定などの開発ツール設定の追加
- LLM向けドキュメント(`.github/copilot-instructions.md`)とシンボリックリンクの追加
- Renovate Bot設定の追加
- `.gitignore`のNix関連パターン追加
- prettierによる`README.md`のコードフェンス記法の統一
- elisp-autofmtによる`auto-sudoedit.el`のフォーマット適用
