### PR TITLE
test: 全関数をカバーするテストを追加

### DIFF
--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -191,16 +191,19 @@
   (with-temp-buffer
     (setq buffer-file-name "/etc/hosts")
     (let ((auto-sudoedit-ask nil)
-          (recentf-list (list "/etc/hosts")))
+          (recentf-list (list "/etc/hosts"))
+          revert-buffer-args)
       (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
                 ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
                 ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
                 ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
-                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+                ((symbol-function 'revert-buffer) (lambda (&rest args) (setq revert-buffer-args args))))
         (auto-sudoedit)
         (should (equal buffer-file-name "/sudo::/etc/hosts"))
         ;; The old path should be removed from recentf-list.
-        (should (null recentf-list))))))
+        (should (null recentf-list))
+        ;; revert-buffer should be called with (t t) to skip confirmation.
+        (should (equal revert-buffer-args '(t t)))))))
 
 (ert-deftest auto-sudoedit/same-user-no-change ()
   "Hook should not change anything when file is owned by current user."
@@ -225,15 +228,17 @@
   (with-temp-buffer
     (setq buffer-file-name "/etc/hosts")
     (let ((auto-sudoedit-ask t)
-          (recentf-list (list "/etc/hosts")))
+          (recentf-list (list "/etc/hosts"))
+          revert-buffer-called)
       (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
                 ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
                 ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
                 ((symbol-function 'y-or-n-p) (lambda (_) t))
                 ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
-                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) (setq revert-buffer-called t))))
         (auto-sudoedit)
-        (should (equal buffer-file-name "/sudo::/etc/hosts"))))))
+        (should (equal buffer-file-name "/sudo::/etc/hosts"))
+        (should revert-buffer-called)))))
 
 (ert-deftest auto-sudoedit/ask-denied ()
   "Hook should not proceed when variable `auto-sudoedit-ask' is t and user denies."
@@ -253,14 +258,16 @@
   (with-temp-buffer
     (setq buffer-file-name "/etc/hosts")
     (let ((auto-sudoedit-ask nil)
-          (recentf-list (list "/some/other/file")))
+          (recentf-list (list "/some/other/file"))
+          revert-buffer-called)
       (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
                 ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
                 ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
                 ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
-                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) (setq revert-buffer-called t))))
         (auto-sudoedit)
-        (should (equal recentf-list (list "/some/other/file")))))))
+        (should (equal recentf-list (list "/some/other/file")))
+        (should revert-buffer-called)))))
 
 (ert-deftest auto-sudoedit/tramp-writable-no-change ()
   "Hook should not reopen when tramp file is already writable."
@@ -283,17 +290,19 @@
     (setq list-buffers-directory "/root/")
     (setq default-directory "/root/")
     (let ((auto-sudoedit-ask nil)
-          (recentf-list nil))
+          (recentf-list nil)
+          revert-buffer-args)
       (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
                 ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
                 ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
                 ((symbol-function 'dired-unadvertise) (lambda (_) nil))
                 ((symbol-function 'dired-advertise) (lambda () nil))
-                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+                ((symbol-function 'revert-buffer) (lambda (&rest args) (setq revert-buffer-args args))))
         (auto-sudoedit)
         (should (equal dired-directory "/sudo::/root/"))
         (should (equal list-buffers-directory "/sudo::/root/"))
-        (should (equal default-directory "/sudo::/root/"))))))
+        (should (equal default-directory "/sudo::/root/"))
+        (should (equal revert-buffer-args '(t t)))))))
 
 (ert-deftest auto-sudoedit-mode/toggle ()
   "Enabling then disabling the mode should restore original hook state."

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -161,6 +161,124 @@
   "For a nonexistent file, should return nil."
   (should (null (auto-sudoedit-file-owner "/nonexistent/path/file"))))
 
+(ert-deftest auto-sudoedit-current-path/file-takes-priority ()
+  "When both variable `buffer-file-name' and variable `list-buffers-directory' are set, file takes priority."
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/file.el")
+    (setq list-buffers-directory "/tmp/dir/")
+    (should (equal (auto-sudoedit-current-path) "/tmp/file.el"))))
+
+(ert-deftest auto-sudoedit-sudoedit/calls-find-file-with-sudo-path ()
+  "Function `auto-sudoedit-sudoedit' should call function `find-file' with the converted sudo path."
+  (let (find-file-called-with)
+    (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+              ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+              ((symbol-function 'find-file) (lambda (path) (setq find-file-called-with path))))
+      (auto-sudoedit-sudoedit "/etc/hosts")
+      (should (equal find-file-called-with "/sudo::/etc/hosts")))))
+
+(ert-deftest auto-sudoedit-sudoedit/same-user-opens-original ()
+  "Function `auto-sudoedit-sudoedit' with same user should open the original path."
+  (let (find-file-called-with)
+    (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "ncaq"))
+              ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+              ((symbol-function 'find-file) (lambda (path) (setq find-file-called-with path))))
+      (auto-sudoedit-sudoedit "/home/ncaq/file.txt")
+      (should (equal find-file-called-with "/home/ncaq/file.txt")))))
+
+(ert-deftest auto-sudoedit/file-buffer-not-writable ()
+  "Hook should change visited file name when file is not writable by another user."
+  (with-temp-buffer
+    (setq buffer-file-name "/etc/hosts")
+    (let ((auto-sudoedit-ask nil)
+          (recentf-list (list "/etc/hosts")))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
+                ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+        (auto-sudoedit)
+        (should (equal buffer-file-name "/sudo::/etc/hosts"))
+        ;; The old path should be removed from recentf-list.
+        (should (null recentf-list))))))
+
+(ert-deftest auto-sudoedit/same-user-no-change ()
+  "Hook should not change anything when file is owned by current user."
+  (with-temp-buffer
+    (setq buffer-file-name "/home/ncaq/file.txt")
+    (let ((auto-sudoedit-ask nil)
+          (original-name buffer-file-name))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "ncaq"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq")))
+        (auto-sudoedit)
+        (should (equal buffer-file-name original-name))))))
+
+(ert-deftest auto-sudoedit/nil-path-no-error ()
+  "Hook should not error when current path is nil."
+  (with-temp-buffer
+    (setq buffer-file-name nil)
+    (setq list-buffers-directory nil)
+    (should-not (auto-sudoedit))))
+
+(ert-deftest auto-sudoedit/ask-confirmed ()
+  "Hook should proceed when variable `auto-sudoedit-ask' is t and user confirms."
+  (with-temp-buffer
+    (setq buffer-file-name "/etc/hosts")
+    (let ((auto-sudoedit-ask t)
+          (recentf-list (list "/etc/hosts")))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
+                ((symbol-function 'y-or-n-p) (lambda (_) t))
+                ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+        (auto-sudoedit)
+        (should (equal buffer-file-name "/sudo::/etc/hosts"))))))
+
+(ert-deftest auto-sudoedit/ask-denied ()
+  "Hook should not proceed when variable `auto-sudoedit-ask' is t and user denies."
+  (with-temp-buffer
+    (setq buffer-file-name "/etc/hosts")
+    (let ((auto-sudoedit-ask t)
+          (original-name buffer-file-name))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
+                ((symbol-function 'y-or-n-p) (lambda (_) nil)))
+        (auto-sudoedit)
+        (should (equal buffer-file-name original-name))))))
+
+(ert-deftest auto-sudoedit/recentf-not-popped-when-different ()
+  "Hook should not pop recentf-list when the top entry differs from current path."
+  (with-temp-buffer
+    (setq buffer-file-name "/etc/hosts")
+    (let ((auto-sudoedit-ask nil)
+          (recentf-list (list "/some/other/file")))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
+                ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+        (auto-sudoedit)
+        (should (equal recentf-list (list "/some/other/file")))))))
+
+(ert-deftest auto-sudoedit-mode/toggle ()
+  "Toggling the mode twice should restore original hook state."
+  (let ((original-find-file-hook (copy-sequence find-file-hook))
+        (original-dired-mode-hook (copy-sequence dired-mode-hook)))
+    (auto-sudoedit-mode 1)
+    (auto-sudoedit-mode -1)
+    (should (equal find-file-hook original-find-file-hook))
+    (should (equal dired-mode-hook original-dired-mode-hook))))
+
+(ert-deftest auto-sudoedit-mode/lighter ()
+  "Mode lighter should be \" ASE\"."
+  (unwind-protect
+      (progn
+        (auto-sudoedit-mode 1)
+        (should (member '(auto-sudoedit-mode " ASE") minor-mode-alist)))
+    (auto-sudoedit-mode -1)))
+
 ;; Local Variables:
 ;; fill-column: 120
 ;; End:

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -282,6 +282,23 @@
         (auto-sudoedit)
         (should (equal buffer-file-name original-name))))))
 
+(ert-deftest auto-sudoedit/tramp-not-writable-reopens ()
+  "Hook should reopen via sudo when tramp file is not writable."
+  (with-temp-buffer
+    (setq buffer-file-name "/ssh:host:/etc/hosts")
+    (let ((auto-sudoedit-ask nil)
+          (recentf-list nil)
+          revert-buffer-called)
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) t))
+                ((symbol-function 'tramp-sh-handle-file-writable-p) (lambda (_) nil))
+                ((symbol-function 'set-visited-file-name) (lambda (path &optional _) (setq buffer-file-name path)))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) (setq revert-buffer-called t))))
+        (auto-sudoedit)
+        (should (string-match-p "sudo:" buffer-file-name))
+        (should revert-buffer-called)))))
+
 (ert-deftest auto-sudoedit/dired-buffer-not-writable ()
   "Hook should update variable `dired-directory' when directory is owned by another user."
   (with-temp-buffer
@@ -291,17 +308,21 @@
     (setq default-directory "/root/")
     (let ((auto-sudoedit-ask nil)
           (recentf-list nil)
-          revert-buffer-args)
+          revert-buffer-args
+          unadvertise-called-with
+          advertise-called)
       (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
                 ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
                 ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
-                ((symbol-function 'dired-unadvertise) (lambda (_) nil))
-                ((symbol-function 'dired-advertise) (lambda () nil))
+                ((symbol-function 'dired-unadvertise) (lambda (dir) (setq unadvertise-called-with dir)))
+                ((symbol-function 'dired-advertise) (lambda () (setq advertise-called t)))
                 ((symbol-function 'revert-buffer) (lambda (&rest args) (setq revert-buffer-args args))))
         (auto-sudoedit)
         (should (equal dired-directory "/sudo::/root/"))
         (should (equal list-buffers-directory "/sudo::/root/"))
         (should (equal default-directory "/sudo::/root/"))
+        (should (equal unadvertise-called-with "/root/"))
+        (should advertise-called)
         (should (equal revert-buffer-args '(t t)))))))
 
 (ert-deftest auto-sudoedit-mode/toggle ()

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -297,6 +297,7 @@
                 ((symbol-function 'revert-buffer) (lambda (&rest _) (setq revert-buffer-called t))))
         (auto-sudoedit)
         (should (string-match-p "sudo:" buffer-file-name))
+        (should (string-match-p "/etc/hosts\\'" buffer-file-name))
         (should revert-buffer-called)))))
 
 (ert-deftest auto-sudoedit/dired-buffer-not-writable ()

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -187,7 +187,7 @@
       (should (equal find-file-called-with "/home/ncaq/file.txt")))))
 
 (ert-deftest auto-sudoedit/file-buffer-not-writable ()
-  "Hook should change visited file name when file is not writable by another user."
+  "Hook should reopen file via sudo when owned by a different user."
   (with-temp-buffer
     (setq buffer-file-name "/etc/hosts")
     (let ((auto-sudoedit-ask nil)
@@ -262,14 +262,51 @@
         (auto-sudoedit)
         (should (equal recentf-list (list "/some/other/file")))))))
 
+(ert-deftest auto-sudoedit/tramp-writable-no-change ()
+  "Hook should not reopen when tramp file is already writable."
+  (with-temp-buffer
+    (setq buffer-file-name "/ssh:host:/etc/hosts")
+    (let ((auto-sudoedit-ask nil)
+          (original-name buffer-file-name))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) t))
+                ((symbol-function 'tramp-sh-handle-file-writable-p) (lambda (_) t)))
+        (auto-sudoedit)
+        (should (equal buffer-file-name original-name))))))
+
+(ert-deftest auto-sudoedit/dired-buffer-not-writable ()
+  "Hook should update variable `dired-directory' when directory is owned by another user."
+  (with-temp-buffer
+    (setq buffer-file-name nil)
+    (setq dired-directory "/root/")
+    (setq list-buffers-directory "/root/")
+    (setq default-directory "/root/")
+    (let ((auto-sudoedit-ask nil)
+          (recentf-list nil))
+      (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+                ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+                ((symbol-function 'tramp-tramp-file-p) (lambda (_) nil))
+                ((symbol-function 'dired-unadvertise) (lambda (_) nil))
+                ((symbol-function 'dired-advertise) (lambda () nil))
+                ((symbol-function 'revert-buffer) (lambda (&rest _) nil)))
+        (auto-sudoedit)
+        (should (equal dired-directory "/sudo::/root/"))
+        (should (equal list-buffers-directory "/sudo::/root/"))
+        (should (equal default-directory "/sudo::/root/"))))))
+
 (ert-deftest auto-sudoedit-mode/toggle ()
-  "Toggling the mode twice should restore original hook state."
+  "Enabling then disabling the mode should restore original hook state."
+  (auto-sudoedit-mode -1)
   (let ((original-find-file-hook (copy-sequence find-file-hook))
         (original-dired-mode-hook (copy-sequence dired-mode-hook)))
-    (auto-sudoedit-mode 1)
-    (auto-sudoedit-mode -1)
-    (should (equal find-file-hook original-find-file-hook))
-    (should (equal dired-mode-hook original-dired-mode-hook))))
+    (unwind-protect
+        (progn
+          (auto-sudoedit-mode 1)
+          (auto-sudoedit-mode -1)
+          (should (equal find-file-hook original-find-file-hook))
+          (should (equal dired-mode-hook original-dired-mode-hook)))
+      (auto-sudoedit-mode -1))))
 
 (ert-deftest auto-sudoedit-mode/lighter ()
   "Mode lighter should be \" ASE\"."

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -135,6 +135,14 @@
   "For a local path, should return function `user-login-name'."
   (should (equal (auto-sudoedit-current-user "/etc/hosts") (user-login-name))))
 
+(ert-deftest auto-sudoedit-current-user/tramp-path ()
+  "For a tramp path, should return the remote user via function `tramp-get-remote-uid'."
+  (cl-letf (((symbol-function 'tramp-get-remote-uid)
+             (lambda (_ id-format)
+               (when (eq id-format 'string)
+                 "remoteuser"))))
+    (should (equal (auto-sudoedit-current-user "/ssh:host:/etc/hosts") "remoteuser"))))
+
 (ert-deftest auto-sudoedit-mode/enable-adds-hooks ()
   "Enabling the mode should add hooks."
   (unwind-protect


### PR DESCRIPTION
未テストだった`auto-sudoedit-sudoedit`と`auto-sudoedit`(hook本体)のテストを追加しました。
hookのテストでは以下を検証しています:

- sudoパスへの変換
- 同ユーザ時の無変更
- nilパス時の安全性
- `auto-sudoedit-ask`による確認ダイアログの承認/拒否
- recentfの条件付きpop

モードのテストにはトグル復元とlighter表示の確認も追加しました。
