### PR TITLE
fix: hop文字列のポート番号フォーマットを修正

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -78,7 +78,7 @@ NEW-USER is the user for sudo."
                     "")
                   host
                   (if port
-                      (concat port "#")
+                      (concat "#" port)
                     ""))))
     ;; 最終メソッドがsudoである場合それ以上の変換は無意味なので行わない。
     (if (equal method "sudo")

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -1,7 +1,7 @@
 ;;; auto-sudoedit.el --- Auto sudo edit by tramp -*- lexical-binding: t -*-
 
 ;; Author: ncaq <ncaq@ncaq.net>
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "26.1")(f "0.19.0"))
 ;; URL: https://github.com/ncaq/auto-sudoedit
 

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -81,8 +81,6 @@
 
 (ert-deftest auto-sudoedit-path-from-tramp-ssh-like/ssh-with-port ()
   "SSH path with port should be converted to sudo preserving the port."
-  :expected-result
-  :failed ;; hop string construction has a port format bug
   (let ((result (auto-sudoedit-path-from-tramp-ssh-like "/ssh:example.com#2222:/etc/hosts" "root")))
     (should (string-match-p "sudo:" result))
     (should (string-match-p "root@" result))

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -85,6 +85,7 @@
     (should (string-match-p "sudo:" result))
     (should (string-match-p "root@" result))
     (should (string-match-p "example\\.com" result))
+    (should (string-match-p "#2222" result))
     (should (string-match-p "/etc/hosts\\'" result))))
 
 (ert-deftest auto-sudoedit-path-from-tramp-ssh-like/already-sudo ()


### PR DESCRIPTION
trampの構文では`host#port`の形式でポートを指定しますが、
`(concat port "#")`で`2222#`のように逆順で生成していました。
`(concat "#" port)`に修正して`#2222`を正しく生成するようにしました。
