### PR TITLE
fix: オーナーに書き込み権限がないファイルでsudo変換をスキップするようにした

### DIFF
--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -1,7 +1,7 @@
 ;;; auto-sudoedit.el --- Auto sudo edit by tramp -*- lexical-binding: t -*-
 
 ;; Author: ncaq <ncaq@ncaq.net>
-;; Version: 1.1.1
+;; Version: 1.1.2
 ;; Package-Requires: ((emacs "26.1")(f "0.19.0"))
 ;; URL: https://github.com/ncaq/auto-sudoedit
 
@@ -40,6 +40,10 @@ USER is nil, when we cannot open via sudo."
          file-owner
          ;; The file owner must be different from our current user so that the sudo makes sense
          (not (string= file-owner (auto-sudoedit-current-user curr-path)))
+         ;; For local files, the file must be writable by its owner,
+         ;; otherwise sudo cannot help (e.g. immutable files on NixOS /nix/store)
+         ;; Skip this check for tramp paths to avoid triggering a remote connection
+         (or (tramp-tramp-file-p curr-path) (auto-sudoedit-owner-writable-p curr-path))
          ;; 変換前のパスと同じでなく(2回めの変換はしない)
          (not (equal curr-path tramp-path)))
         (cons file-owner tramp-path)
@@ -55,6 +59,12 @@ USER is nil, when we cannot open via sudo."
       ;; We can't just go by the user in the tramp filename, because it may have been omitted
       (tramp-get-remote-uid (tramp-dissect-file-name path) 'string)
     (user-login-name)))
+
+(defun auto-sudoedit-owner-writable-p (path)
+  "Check if the owner of PATH has write permission.
+If the file modes cannot be determined, assume writable."
+  (let ((modes (file-modes path)))
+    (or (null modes) (not (zerop (logand modes #o200))))))
 
 (defun auto-sudoedit-path-from-tramp-ssh-like (curr-path new-user)
   "Argument CURR-PATH is tramp path(that use protocols such as ssh).

--- a/auto-sudoedit.el
+++ b/auto-sudoedit.el
@@ -41,7 +41,7 @@ USER is nil, when we cannot open via sudo."
          ;; The file owner must be different from our current user so that the sudo makes sense
          (not (string= file-owner (auto-sudoedit-current-user curr-path)))
          ;; For local files, the file must be writable by its owner,
-         ;; otherwise sudo cannot help (e.g. immutable files on NixOS /nix/store)
+         ;; otherwise sudo cannot help (e.g. read-only files on NixOS /nix/store)
          ;; Skip this check for tramp paths to avoid triggering a remote connection
          (or (tramp-tramp-file-p curr-path) (auto-sudoedit-owner-writable-p curr-path))
          ;; 変換前のパスと同じでなく(2回めの変換はしない)

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -33,6 +33,21 @@
       (should (null (car result)))
       (should (equal (cdr result) "/some/path")))))
 
+(ert-deftest auto-sudoedit-path/immutable-file-not-converted ()
+  "File not writable even by owner (e.g. NixOS /nix/store)
+should not be converted to sudo path.
+On NixOS, files in /nix/store are immutable (no write permission for anyone).
+Sudo cannot help with these files, so converting to a tramp sudo path is pointless."
+  :expected-result
+  :failed
+  (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+            ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+            ;; Simulate a file with mode #o444 (r--r--r--), not writable by anyone
+            ((symbol-function 'file-modes) (lambda (_) #o444)))
+    (let ((result (auto-sudoedit-path "/nix/store/some-hash-pkg/etc/config")))
+      (should (null (car result)))
+      (should (equal (cdr result) "/nix/store/some-hash-pkg/etc/config")))))
+
 (ert-deftest auto-sudoedit-path/already-sudo ()
   "Already a sudo tramp path should not be converted again."
   (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -46,6 +46,18 @@ Sudo cannot help with these files, so converting to a tramp sudo path is pointle
       (should (null (car result)))
       (should (equal (cdr result) "/nix/store/some-hash-pkg/etc/config")))))
 
+(ert-deftest auto-sudoedit-path/tramp-skips-owner-writable-check ()
+  "For tramp paths, auto-sudoedit-owner-writable-p should NOT be called to avoid triggering a remote connection."
+  (let ((called nil))
+    (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
+              ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
+              ((symbol-function 'auto-sudoedit-owner-writable-p)
+               (lambda (_)
+                 (setq called t)
+                 nil)))
+      (auto-sudoedit-path "/ssh:host:/etc/hosts")
+      (should-not called))))
+
 (ert-deftest auto-sudoedit-path/already-sudo ()
   "Already a sudo tramp path should not be converted again."
   (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -33,10 +33,10 @@
       (should (null (car result)))
       (should (equal (cdr result) "/some/path")))))
 
-(ert-deftest auto-sudoedit-path/immutable-file-not-converted ()
+(ert-deftest auto-sudoedit-path/read-only-file-not-converted ()
   "File not writable even by owner (e.g. NixOS /nix/store)
 should not be converted to sudo path.
-On NixOS, files in /nix/store are immutable (no write permission for anyone).
+On NixOS, files in /nix/store are read-only (no write permission for anyone).
 Sudo cannot help with these files, so converting to a tramp sudo path is pointless."
   (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
             ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))

--- a/test/auto-sudoedit-test.el
+++ b/test/auto-sudoedit-test.el
@@ -38,8 +38,6 @@
 should not be converted to sudo path.
 On NixOS, files in /nix/store are immutable (no write permission for anyone).
 Sudo cannot help with these files, so converting to a tramp sudo path is pointless."
-  :expected-result
-  :failed
   (cl-letf (((symbol-function 'auto-sudoedit-file-owner) (lambda (_) "root"))
             ((symbol-function 'auto-sudoedit-current-user) (lambda (_) "ncaq"))
             ;; Simulate a file with mode #o444 (r--r--r--), not writable by anyone
@@ -182,6 +180,31 @@ Sudo cannot help with these files, so converting to a tramp sudo path is pointle
 (ert-deftest auto-sudoedit-file-owner/nonexistent-file ()
   "For a nonexistent file, should return nil."
   (should (null (auto-sudoedit-file-owner "/nonexistent/path/file"))))
+
+(ert-deftest auto-sudoedit-owner-writable-p/writable ()
+  "File with owner write permission should return non-nil."
+  (cl-letf (((symbol-function 'file-modes) (lambda (_) #o644)))
+    (should (auto-sudoedit-owner-writable-p "/some/path"))))
+
+(ert-deftest auto-sudoedit-owner-writable-p/not-writable ()
+  "File without owner write permission should return nil."
+  (cl-letf (((symbol-function 'file-modes) (lambda (_) #o444)))
+    (should-not (auto-sudoedit-owner-writable-p "/some/path"))))
+
+(ert-deftest auto-sudoedit-owner-writable-p/no-permission ()
+  "File with no permissions at all should return nil."
+  (cl-letf (((symbol-function 'file-modes) (lambda (_) #o000)))
+    (should-not (auto-sudoedit-owner-writable-p "/some/path"))))
+
+(ert-deftest auto-sudoedit-owner-writable-p/modes-unknown ()
+  "When file modes cannot be determined, should assume writable."
+  (cl-letf (((symbol-function 'file-modes) (lambda (_) nil)))
+    (should (auto-sudoedit-owner-writable-p "/some/path"))))
+
+(ert-deftest auto-sudoedit-owner-writable-p/group-writable-only ()
+  "File writable by group but not owner should return nil."
+  (cl-letf (((symbol-function 'file-modes) (lambda (_) #o464)))
+    (should-not (auto-sudoedit-owner-writable-p "/some/path"))))
 
 (ert-deftest auto-sudoedit-current-path/file-takes-priority ()
   "When both variable `buffer-file-name' and variable `list-buffers-directory' are set, file takes priority."


### PR DESCRIPTION
NixOSの`/nix/store`内のファイルはimmutableでrootでも書き込みできません。
このようなファイルに対してsudoのtrampパスに変換しても編集できないため、
`auto-sudoedit-owner-writable-p`でオーナーの書き込みビット(`#o200`)を確認し、
権限がない場合は変換をスキップするようにしました。
trampパスの場合はリモート接続の発生を避けるためこのチェックをスキップします。

`auto-sudoedit-owner-writable-p`自体の単体テストも追加しました。

close #21
