### PR TITLE
refactor: konokaマーケットプレイスのref固定を解除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,7 @@
     "konoka": {
       "source": {
         "source": "github",
-        "repo": "ncaq/konoka",
-        "ref": "v8.0.0"
+        "repo": "ncaq/konoka"
       }
     }
   },


### PR DESCRIPTION
refactor: konokaマーケットプレイスのref固定を解除

konokaは私が個人的に管理しているマーケットプレイスなので、
ref固定によるサプライチェーン上の懸念は実質的にありません。

一方でkonokaをリリースするたびに、
renovateが各リポジトリへ大量の更新PRを生成し、
それらを処理する手間が無視できなくなってきました。

バージョン固定による再現性の利益よりも、
追従の手間のほうが上回っていると判断したため、
refを外してその時点のClaude Codeが解決するheadに追従させます。
